### PR TITLE
Elm 0.18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 # Ignore build or dist files
-/elm-stuff
+elm-stuff

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.3",
+    "version": "1.0.4",
     "summary": "Split strings into chunks",
     "repository": "https://github.com/circuithub/elm-string-split.git",
     "license": "MIT",
@@ -10,7 +10,7 @@
         "String.Split"
     ],
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 4.0.0"
+        "elm-lang/core": "5.1.1 <= v < 6.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.17.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/tests/StringSplitTests.elm
+++ b/tests/StringSplitTests.elm
@@ -1,0 +1,23 @@
+module StringSplitTests exposing (..)
+
+import Expect
+import Test exposing (..)
+import String.Split exposing (..)
+
+
+chunksOfLeftTest : Test
+chunksOfLeftTest =
+    test "chuncksOfLeft splits string into a list of smaller strings of length 3 from the left" <|
+        \_ ->
+            "abcdefgh"
+                |> chunksOfLeft 3
+                |> Expect.equal [ "abc", "def", "gh" ]
+
+
+chunksOfRightTest : Test
+chunksOfRightTest =
+    test "chuncksOfRight splits string into a list of smaller strings of length 3 from the right" <|
+        \_ ->
+            "abcdefgh"
+                |> chunksOfRight 3
+                |> Expect.equal [ "ab", "cde", "fgh" ]

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0.0",
+    "summary": "Test Suites",
+    "repository": "https://github.com/circuithub/elm-string-split.git",
+    "license": "MIT",
+    "source-directories": [
+        "..\\src",
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-community/elm-test": "4.0.0 <= v < 5.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}


### PR DESCRIPTION
Your code had already been updated for Elm 0.18, but without the changes to `elm-package.json`, elm-package refuses to add it to as a dependency for an Elm 0.18 project.

I also added a couple unit tests.